### PR TITLE
Add Release plugin configuration on master pom.xml to support safe release with Jenkins PaaS

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -26,7 +26,7 @@
 	 		Copyright (c) 2012 GFT Appverse, S.L., Sociedad Unipersonal.
 			
 			 This Source Code Form is subject to the terms of the Appverse Public License 
-			 Version 2.0 (‚ÄúAPL v2.0‚Äù). If a copy of the APL was not distributed with this 
+			 Version 2.0 (ìAPL v2.0î). If a copy of the APL was not distributed with this 
 			 file, You can obtain one at http://www.appverse.mobi/licenses/apl_v2.0.pdf. [^]
 			
 			 Redistribution and use in source and binary forms, with or without modification, 
@@ -73,6 +73,16 @@
 	<build>
 		<defaultGoal>clean package</defaultGoal>
 
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                </configuration>
+            </plugin>
+        </plugins>
 		<pluginManagement>
 			<plugins>
 				<plugin>


### PR DESCRIPTION
Without this setup of the release pluing it is not possible to read the gpg.passphrase property from the settings.xml at the server. 

Alternatives are to set this property in the pom.xml that will make it publicly available or use command line parameters that are currently bugged and in discussion between gpg and release plugin teams. 
